### PR TITLE
🐛 [FIX] 툴 겹치는 현상 및 그리드를 벗어나는 현상 해결

### DIFF
--- a/WorkItTalkIt/WorkItTalkIt.xcodeproj/project.pbxproj
+++ b/WorkItTalkIt/WorkItTalkIt.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		7B792EB728571D04004ECEBE /* ToolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B792EB628571D04004ECEBE /* ToolView.swift */; };
 		7B792EB928571D23004ECEBE /* ToolView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7B792EB828571D23004ECEBE /* ToolView.xib */; };
 		7B9363DE2854C654007FA220 /* AllSizeToolView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9363DD2854C654007FA220 /* AllSizeToolView.swift */; };
+		ABAA2343285AD2920082E425 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAA2342285AD2920082E425 /* UIColor+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +66,7 @@
 		7B792EB628571D04004ECEBE /* ToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolView.swift; sourceTree = "<group>"; };
 		7B792EB828571D23004ECEBE /* ToolView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ToolView.xib; sourceTree = "<group>"; };
 		7B9363DD2854C654007FA220 /* AllSizeToolView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllSizeToolView.swift; sourceTree = "<group>"; };
+		ABAA2342285AD2920082E425 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +123,7 @@
 				077616C82852E21900EB1E97 /* SceneDelegate.swift */,
 				077616CA2852E21900EB1E97 /* ViewController.swift */,
 				7B9363DD2854C654007FA220 /* AllSizeToolView.swift */,
+				ABAA2342285AD2920082E425 /* UIColor+Extension.swift */,
 				077616CC2852E21900EB1E97 /* Main.storyboard */,
 				7B792EB428561A20004ECEBE /* AllSizeToolView.storyboard */,
 				077616CF2852E21A00EB1E97 /* Assets.xcassets */,
@@ -326,6 +329,7 @@
 				0776184028582DC000EB1E97 /* GridViewController.swift in Sources */,
 				077616CB2852E21900EB1E97 /* ViewController.swift in Sources */,
 				077616C72852E21900EB1E97 /* AppDelegate.swift in Sources */,
+				ABAA2343285AD2920082E425 /* UIColor+Extension.swift in Sources */,
 				7B9363DE2854C654007FA220 /* AllSizeToolView.swift in Sources */,
 				0776184628582E8200EB1E97 /* CGPoint+.swift in Sources */,
 				077616C92852E21900EB1E97 /* SceneDelegate.swift in Sources */,

--- a/WorkItTalkIt/WorkItTalkIt/Grid/GridViewController.swift
+++ b/WorkItTalkIt/WorkItTalkIt/Grid/GridViewController.swift
@@ -122,11 +122,14 @@ class GridViewController: UIViewController {
         var coordinate: CGPoint
         var movable = true
 
-        coordinate = CGPoint(x: originPosition.x + CGFloat((attachedView.size.col - 1) * (unitSize + unitSpace)), y: originPosition.y + CGFloat((attachedView.size.row - 1) * (unitSize + unitSpace)))
+        coordinate = CGPoint(x: originPosition.x + CGFloat((attachedView.size.col - 1) * (unitSize + unitSpace)), y: originPosition.y)
+        if !gridPositions.contains(coordinate) { movable = false }
 
-        if !gridPositions.contains(coordinate) {
-            movable = false
-        }
+        coordinate = CGPoint(x: originPosition.x + CGFloat((attachedView.size.col - 1) * (unitSize + unitSpace)), y: originPosition.y + CGFloat((attachedView.size.row - 1) * (unitSize + unitSpace)))
+        if !gridPositions.contains(coordinate) { movable = false }
+
+        coordinate = CGPoint(x: originPosition.x, y: originPosition.y + CGFloat((attachedView.size.row - 1) * (unitSize + unitSpace)))
+        if !gridPositions.contains(coordinate) { movable = false }
 
         return movable
     }
@@ -160,7 +163,7 @@ class GridViewController: UIViewController {
 
     private func addPreviousPositions(attachedView: ToolView) {
         if attachedView.grids.isEmpty { return }
-        for _ in 1...attachedView.grids.count {
+        for _ in attachedView.grids {
             gridPositionViews.append(attachedView.grids.removeFirst())
         }
     }

--- a/WorkItTalkIt/WorkItTalkIt/Grid/GridViewController.swift
+++ b/WorkItTalkIt/WorkItTalkIt/Grid/GridViewController.swift
@@ -189,7 +189,6 @@ class GridViewController: UIViewController {
                 attachedView.grids.append(gridPositionViews.remove(at: positionIndex))
             }
         }
-        print(attachedView.grids.count)
     }
 
     private func addPreviousPositions(attachedView: ToolView) {

--- a/WorkItTalkIt/WorkItTalkIt/Tool/ToolView.swift
+++ b/WorkItTalkIt/WorkItTalkIt/Tool/ToolView.swift
@@ -50,6 +50,7 @@ class ToolView: UIView {
     var height: Int {
         return size.row * Grid.shared.unitSize + (size.row - 1) * Grid.shared.unitSpace
     }
+    var grids = [UIView]()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/WorkItTalkIt/WorkItTalkIt/UIColor+Extension.swift
+++ b/WorkItTalkIt/WorkItTalkIt/UIColor+Extension.swift
@@ -1,0 +1,38 @@
+//
+//  UIColor+Extension.swift
+//  WorkItTalkIt
+//
+//  Created by Somin Park on 2022/06/16.
+//
+import UIKit
+
+enum AssetsColor {
+    case sidebarColor
+    case modalViewColor
+    case boardColor
+    case mainColor
+    case selectedYellowColor
+    case disabledGrayColor
+    case storageAreaColor
+}
+
+extension UIColor {
+    static func appColor(_ name: AssetsColor) -> UIColor {
+        switch name {
+        case .sidebarColor:
+            return UIColor(red: 244/255, green: 244/255, blue: 244/255, alpha: 0.9)
+        case .modalViewColor:
+            return UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 0.9)
+        case .boardColor:
+            return UIColor(red: 251/255, green: 251/255, blue: 251/255, alpha: 1)
+        case .mainColor:
+            return UIColor(red: 19/255, green: 90/255, blue: 165/255, alpha: 1)
+        case .selectedYellowColor:
+            return UIColor(red: 247/255, green: 207/255, blue: 116/255, alpha: 1)
+        case .disabledGrayColor:
+            return UIColor(red: 209/255, green: 209/255, blue: 214/255, alpha: 1)
+        case .storageAreaColor:
+            return UIColor(red: 243/255, green: 243/255, blue: 243/255, alpha: 1)
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 관련 이슈

- close #13 
- close #14 

## ✅ 구현/변경 사항 및 이유

- 툴이 겹치지 않도록 구현
- 툴을 그리드 바운더리 안에서만 배치할 수 있도록 구현

## ✅ PR Point

- 현재 가장 가까운 그리드로 이동했을 때 
  툴의 테두리 그리드 좌표가 레이아웃 외부에 있거나 다른 툴과 겹치는 경우 이동하지 못하도록 변경했습니다.
  (이런 그리드를 제외한 그리드 중에서 가장 가까운 그리드로 이동합니다)


## ✅ 참고 사항
<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
- SceneDelegate 파일에서 해당 부분을 변경하면 GridViewController를 실행할 수 있습니다

```
func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
        guard let windowScene = (scene as? UIWindowScene) else { return }
        window = UIWindow(windowScene: windowScene)
        let mainViewController = GridViewController()

        window?.rootViewController = mainViewController
        window?.makeKeyAndVisible()
    }
```  


https://user-images.githubusercontent.com/51108729/174146102-c0f85878-9db5-4f66-8c94-f3124b517f33.mov


